### PR TITLE
Implementacion de la Barra de Vida del Mob

### DIFF
--- a/src/main/java/net/idsquad/rotabombalinomod/entity/custom/TralaleroEntity.java
+++ b/src/main/java/net/idsquad/rotabombalinomod/entity/custom/TralaleroEntity.java
@@ -1,7 +1,11 @@
 package net.idsquad.rotabombalinomod.entity.custom;
 
 import net.idsquad.rotabombalinomod.item.ModItems;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.BossEvent;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.AnimationState;
@@ -23,6 +27,9 @@ import org.jetbrains.annotations.Nullable;
 public class TralaleroEntity extends Monster {
     public final AnimationState idleAnimationState = new AnimationState();
     private int idleAnimationTimeout = 0;
+
+    public final ServerBossEvent bossEvent = new ServerBossEvent(Component.literal("Tralalero Tralala"),
+            BossEvent.BossBarColor.BLUE, BossEvent.BossBarOverlay.NOTCHED_20);
 
     public TralaleroEntity(EntityType<? extends Monster> pEntityType, Level pLevel) {
         super(pEntityType, pLevel);
@@ -77,5 +84,26 @@ public class TralaleroEntity extends Monster {
         super.dropCustomDeathLoot(level, source, causedByPlayer);
 
         this.spawnAtLocation(new ItemStack(ModItems.TRALALERO_SCALE.get(), 8));
+    }
+
+        /* BOSS BAR */
+
+    @Override
+    public void startSeenByPlayer(ServerPlayer pServerPlayer) {
+        super.startSeenByPlayer(pServerPlayer);
+        this.bossEvent.addPlayer(pServerPlayer);
+    }
+
+    @Override
+    public void stopSeenByPlayer(ServerPlayer pServerPlayer) {
+        super.stopSeenByPlayer(pServerPlayer);
+        this.bossEvent.removePlayer(pServerPlayer);
+        }
+
+
+    @Override
+    public void aiStep() {
+        super.aiStep();
+        this.bossEvent.setProgress(this.getHealth() / this.getMaxHealth());
     }
 }


### PR DESCRIPTION
Se ha implementado la barra de vida tipo jefe para el mob Tralalero Tralala, la cual ahora se muestra al momento de su invocación. Esta mejora aporta mayor inmersión al combate y refuerza la presencia del mob como jefe dentro del juego.

- Cambios:
   - Implementación de la barra de vida del mob Tralalero Tralala visible durante el combate.

- Próximos pasos:
  - Añadir propiedades especiales a los Zapatos de Tralalero.
  - Retexturizar el Altar de Invocación para mejorar su apariencia visual.

![Imagen de WhatsApp 2025-05-14 a las 15 42 06_9f23bfd2](https://github.com/user-attachments/assets/d3fea184-0a12-4e68-bb77-5c0ddd8ba2db)
